### PR TITLE
Fixing kernel ROOT with conda

### DIFF
--- a/.github/workflows/kernel-images.yml
+++ b/.github/workflows/kernel-images.yml
@@ -5,36 +5,36 @@ on:
     tags:
       - "*"
 jobs:
-  #kernel-ROOT:
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - name: Checkout
-  #      uses: actions/checkout@v2
-  #    - name: Set env
-  #      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-  #    - name: Set up QEMU
-  #      uses: docker/setup-qemu-action@v1
-  #    - name: Set up Docker Buildx
-  #      uses: docker/setup-buildx-action@v1
-  #    - name: Login to GitHub Container Registry
-  #      uses: docker/login-action@v1
-  #      with:
-  #        registry: ghcr.io
-  #        username: ${{ github.repository_owner }}
-  #        password: ${{ secrets.GITHUB_TOKEN }}
-  #    - name: Get Repo Owner
-  #      id: get_repo_owner
-  #      run: echo ::set-output name=repo_owner::$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')
-  #    - name: Build container kernel-ROOT
-  #      uses: docker/build-push-action@v2
-  #      with:
-  #        context: ./kernel-ROOT/
-  #        outputs: "type=registry,push=true"
-  #        tags: |
-  #          ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/kernel-root:${{ env.RELEASE_VERSION }}
-  #          ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/kernel-root:latest
-  #        file: ./kernel-ROOT/Dockerfile
-  #        platforms: linux/amd64
+  kernel-ROOT:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Repo Owner
+        id: get_repo_owner
+        run: echo ::set-output name=repo_owner::$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')
+      - name: Build container kernel-ROOT
+        uses: docker/build-push-action@v2
+        with:
+          context: ./kernel-ROOT/
+          outputs: "type=registry,push=true"
+          tags: |
+            ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/kernel-root:${{ env.RELEASE_VERSION }}
+            ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/kernel-root:latest
+          file: ./kernel-ROOT/Dockerfile
+          platforms: linux/amd64
   kernel-Coffea:
     runs-on: ubuntu-latest
     steps:
@@ -65,41 +65,41 @@ jobs:
             ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/kernel-coffea:latest
           file: ./kernel-Coffea/Dockerfile
           platforms: linux/amd64
-  #kernel-mkShapesRDF:
-  #  needs: kernel-ROOT
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - name: Checkout
-  #      uses: actions/checkout@v2
-  #    - name: Set env
-  #      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-  #    - name: Set up QEMU
-  #      uses: docker/setup-qemu-action@v1
-  #    - name: Set up Docker Buildx
-  #      uses: docker/setup-buildx-action@v1
-  #    - name: Login to GitHub Container Registry
-  #      uses: docker/login-action@v1
-  #      with:
-  #        registry: ghcr.io
-  #        username: ${{ github.repository_owner }}
-  #        password: ${{ secrets.GITHUB_TOKEN }}
-  #    - name: Get Repo Owner
-  #      id: get_repo_owner
-  #      run: echo ::set-output name=repo_owner::$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')
-  #    - uses: cvmfs-contrib/github-action-cvmfs@v4
-  #    - name: Take lib files from CVMFS
-  #      run: |
-  #        rsync -ar --exclude 'python3.9' --exclude 'libROO*' --exclude 'libRoo*' /cvmfs/sft.cern.ch/lcg/views/LCG_103/x86_64-ubuntu2004-gcc9-opt/lib ./kernel-mkShapesRDF/xrdfs_locallib
-  #    - name: Build container kernel-mkShapesRDF
-  #      uses: docker/build-push-action@v2
-  #      with:
-  #        context: ./kernel-mkShapesRDF/
-  #        outputs: "type=registry,push=true"
-  #        tags: |
-  #          ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/kernel-mkshapesrdf:${{ env.RELEASE_VERSION }}
-  #          ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/kernel-mkshapesrdf:latest
-  #        file: ./kernel-mkShapesRDF/Dockerfile
-  #        platforms: linux/amd64
+  kernel-mkShapesRDF:
+    needs: kernel-ROOT
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Repo Owner
+        id: get_repo_owner
+        run: echo ::set-output name=repo_owner::$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')
+      - uses: cvmfs-contrib/github-action-cvmfs@v4
+      - name: Take lib files from CVMFS
+        run: |
+          rsync -ar --exclude 'python3.9' --exclude 'libROO*' --exclude 'libRoo*' /cvmfs/sft.cern.ch/lcg/views/LCG_103/x86_64-ubuntu2004-gcc9-opt/lib ./kernel-mkShapesRDF/xrdfs_locallib
+      - name: Build container kernel-mkShapesRDF
+        uses: docker/build-push-action@v2
+        with:
+          context: ./kernel-mkShapesRDF/
+          outputs: "type=registry,push=true"
+          tags: |
+            ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/kernel-mkshapesrdf:${{ env.RELEASE_VERSION }}
+            ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/kernel-mkshapesrdf:latest
+          file: ./kernel-mkShapesRDF/Dockerfile
+          platforms: linux/amd64
   kernel-PocketCoffea:
     needs: kernel-Coffea
     runs-on: ubuntu-latest

--- a/kernel-ROOT/Dockerfile
+++ b/kernel-ROOT/Dockerfile
@@ -76,6 +76,7 @@ RUN python3 -m pip install ipykernel ipywidgets matplotlib
 RUN apt-get -y install davix
 
 RUN conda install -c conda-forge -y root xrootd boost-cpp
+RUN conda install -c conda-forge -y libsqlite --force-reinstall
 
 RUN echo /usr/local/lib/root >> /etc/ld.so.conf && ldconfig
 ENV PYTHONPATH /usr/local/lib/root:$PYTHONPATH

--- a/kernel-ROOT/Dockerfile
+++ b/kernel-ROOT/Dockerfile
@@ -11,6 +11,11 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
 # Put conda in path so we can use conda activate
 ENV PATH=$CONDA_DIR/bin:$PATH
 
+RUN conda init bash
+RUN echo "conda activate base" >> ~/.bashrc
+
+SHELL ["conda", "run", "-n", "base", "/bin/bash", "-c"]
+
 RUN conda install -c conda-forge -y python=3.11
 #RUN conda install conda-libmamba-solver
 
@@ -70,7 +75,7 @@ RUN python3 -m pip install ipykernel ipywidgets matplotlib
 
 RUN apt-get -y install davix
 
-RUN conda install -c conda-forge -y root xrootd
+RUN conda install -c conda-forge -y root xrootd boost-cpp
 
 RUN echo /usr/local/lib/root >> /etc/ld.so.conf && ldconfig
 ENV PYTHONPATH /usr/local/lib/root:$PYTHONPATH

--- a/kernel-ROOT/Dockerfile
+++ b/kernel-ROOT/Dockerfile
@@ -16,8 +16,7 @@ RUN echo "conda activate base" >> ~/.bashrc
 
 SHELL ["conda", "run", "-n", "base", "/bin/bash", "-c"]
 
-RUN conda install -c conda-forge -y python=3.11
-#RUN conda install conda-libmamba-solver
+RUN conda install -c conda-forge -y python=3.11 root boost-cpp
 
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /bin/tini
@@ -74,9 +73,6 @@ RUN apt-get update && \
 RUN python3 -m pip install ipykernel ipywidgets matplotlib
 
 RUN apt-get -y install davix
-
-RUN conda install -c conda-forge -y libsqlite --force-reinstall
-RUN conda install -c conda-forge -y root xrootd boost-cpp
 
 RUN echo /usr/local/lib/root >> /etc/ld.so.conf && ldconfig
 ENV PYTHONPATH /usr/local/lib/root:$PYTHONPATH

--- a/kernel-ROOT/Dockerfile
+++ b/kernel-ROOT/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Europe/Zurich #apt-get i
 
 RUN python3 -m pip install \
     htcondor \
-    click==7.1.2 \
+    click \
     ipython \
     "dask[complete]==2024.4.1" \
     dask-jobqueue==0.7.3

--- a/kernel-ROOT/Dockerfile
+++ b/kernel-ROOT/Dockerfile
@@ -70,8 +70,6 @@ RUN python3 -m pip install ipykernel ipywidgets matplotlib
 
 RUN apt-get -y install davix
 
-RUN conda install -c conda-forge -y boost-cpp
-
 RUN conda install -c conda-forge -y root xrootd
 
 RUN echo /usr/local/lib/root >> /etc/ld.so.conf && ldconfig

--- a/kernel-ROOT/Dockerfile
+++ b/kernel-ROOT/Dockerfile
@@ -75,8 +75,8 @@ RUN python3 -m pip install ipykernel ipywidgets matplotlib
 
 RUN apt-get -y install davix
 
-RUN conda install -c conda-forge -y root xrootd boost-cpp
 RUN conda install -c conda-forge -y libsqlite --force-reinstall
+RUN conda install -c conda-forge -y root xrootd boost-cpp
 
 RUN echo /usr/local/lib/root >> /etc/ld.so.conf && ldconfig
 ENV PYTHONPATH /usr/local/lib/root:$PYTHONPATH

--- a/kernel-ROOT/Dockerfile
+++ b/kernel-ROOT/Dockerfile
@@ -33,7 +33,7 @@ RUN python3 -m pip install \
     htcondor \
     click==7.1.2 \
     ipython \
-    "dask[complete]==2021.11.1" \
+    "dask[complete]==2024.4.1" \
     dask-jobqueue==0.7.3
 
 WORKDIR /usr/local/share/comp-dev-cms-ita

--- a/kernel-ROOT/Dockerfile
+++ b/kernel-ROOT/Dockerfile
@@ -70,8 +70,9 @@ RUN python3 -m pip install ipykernel ipywidgets matplotlib
 
 RUN apt-get -y install davix
 
+RUN conda install -c conda-forge -y boost-cpp
 
-RUN conda install -c conda-forge -y root xrootd boost-cpp
+RUN conda install -c conda-forge -y root xrootd
 
 RUN echo /usr/local/lib/root >> /etc/ld.so.conf && ldconfig
 ENV PYTHONPATH /usr/local/lib/root:$PYTHONPATH

--- a/kernel-ROOT/Dockerfile
+++ b/kernel-ROOT/Dockerfile
@@ -71,7 +71,7 @@ RUN python3 -m pip install ipykernel ipywidgets matplotlib
 RUN apt-get -y install davix
 
 
-RUN conda install -c conda-forge -y root xrootd
+RUN conda install -c conda-forge -y root xrootd boost-cpp
 
 RUN echo /usr/local/lib/root >> /etc/ld.so.conf && ldconfig
 ENV PYTHONPATH /usr/local/lib/root:$PYTHONPATH

--- a/kernel-mkShapesRDF/Dockerfile
+++ b/kernel-mkShapesRDF/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tommasodiotalevi/kernel-root
+FROM ghcr.io/comp-dev-cms-ita/kernel-root
 
 WORKDIR /code
 

--- a/kernel-mkShapesRDF/Dockerfile
+++ b/kernel-mkShapesRDF/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /code
 USER root
 
 RUN apt-get update && \
-    apt-get install -y vim rsync sqlite3 && \
+    apt-get install -y vim rsync && \
     apt-get install -y voms-clients && \
     apt-get -y install python3.11-venv ninja-build && \
     echo "deb http://archive.ubuntu.com/ubuntu/ jammy main universe" >> /etc/apt/sources.list.d/xrootd.list && \

--- a/kernel-mkShapesRDF/Dockerfile
+++ b/kernel-mkShapesRDF/Dockerfile
@@ -1,11 +1,11 @@
-FROM ghcr.io/comp-dev-cms-ita/kernel-root
+FROM ghcr.io/tommasodiotalevi/kernel-root
 
 WORKDIR /code
 
 USER root
 
 RUN apt-get update && \
-    apt-get install -y vim rsync && \
+    apt-get install -y vim rsync sqlite3 && \
     apt-get install -y voms-clients && \
     apt-get -y install python3.11-venv ninja-build && \
     echo "deb http://archive.ubuntu.com/ubuntu/ jammy main universe" >> /etc/apt/sources.list.d/xrootd.list && \


### PR DESCRIPTION
Makes the `kernel-ROOT` (6.32.2 installed with conda) work correctly.

- Including `boost-cpp` conda package.
- `kernel-mkShapesRDF` seems to work as well.
